### PR TITLE
Use jdk 24

### DIFF
--- a/.github/workflows/funnyapp-ci.yml
+++ b/.github/workflows/funnyapp-ci.yml
@@ -2,7 +2,7 @@ name: Funny App Build and Deploy
 
 on:
   push:
-    branches: [ main, 'VID-*' ]
+    branches: [ main, 'VID-*', 'use_jdk_24' ]
     paths:
       - 'api/**'
       - '.github/workflows/funnyapp-ci.yml'
@@ -37,7 +37,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '24'
           cache: 'maven'
 
       # Build the project without running tests
@@ -75,7 +75,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '24'
           cache: 'maven'
 
       - name: Cache SonarQube packages

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -30,7 +30,7 @@
         <maven-checkstyle-plugin.version>3.3.0</maven-checkstyle-plugin.version>
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
         <jsonwebtoken.version>0.11.5</jsonwebtoken.version>
-        <springdoc-openapi.version>2.8.9</springdoc-openapi.version>
+        <springdoc-openapi.version>2.7.0</springdoc-openapi.version>
         <skipTests>false</skipTests>
         <skipCoverage>false</skipCoverage>
         <jacoco.minimum.coverage>0.07</jacoco.minimum.coverage>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -22,7 +22,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>24</java.version>
         <lombok.version>1.18.38</lombok.version>
-        <common-lang.version>3.12.0</common-lang.version>
+        <common-lang.version>3.17.0</common-lang.version>
         <json-lib.version>20231013</json-lib.version>
         <commons-validator.version>1.7</commons-validator.version>
         <spring-boot-admin-starter-client.version>3.2.5</spring-boot-admin-starter-client.version>
@@ -154,6 +154,7 @@
             <artifactId>liquibase-core</artifactId>
             <version>4.32.0</version>
         </dependency>
+
 
         <!-- Prometheus Metrics -->
         <dependency>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -30,7 +30,7 @@
         <maven-checkstyle-plugin.version>3.3.0</maven-checkstyle-plugin.version>
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
         <jsonwebtoken.version>0.11.5</jsonwebtoken.version>
-        <springdoc-openapi.version>2.5.0</springdoc-openapi.version>
+        <springdoc-openapi.version>2.8.9</springdoc-openapi.version>
         <skipTests>false</skipTests>
         <skipCoverage>false</skipCoverage>
         <jacoco.minimum.coverage>0.07</jacoco.minimum.coverage>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -14,14 +14,14 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.5</version>
+        <version>3.5.0</version>
         <relativePath/>
     </parent>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>21</java.version>
-        <lombok.version>1.18.30</lombok.version>
+        <java.version>24</java.version>
+        <lombok.version>1.18.38</lombok.version>
         <common-lang.version>3.12.0</common-lang.version>
         <json-lib.version>20231013</json-lib.version>
         <commons-validator.version>1.7</commons-validator.version>
@@ -152,6 +152,7 @@
         <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
+            <version>4.32.0</version>
         </dependency>
 
         <!-- Prometheus Metrics -->
@@ -210,6 +211,19 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Override version byte-buddy -->
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>1.17.5</version> <!-- >= 1.14.10 trở lên -->
+        </dependency>
+
+        <!-- Override version mockito -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.18.0</version> <!-- hoặc mới hơn -->
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
@@ -219,6 +233,11 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-properties-migrator</artifactId>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 
@@ -236,6 +255,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>3.5.3</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -254,7 +274,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.11</version>
+                <version>0.8.13</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>
@@ -324,6 +344,21 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <release>24</release>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Here’s a summary of the pull request:  
**Title:** Use jdk 24  
**URL:** https://github.com/nguyenhuuca/assessment/pull/14

---

### Purpose
The main objective of this pull request is to update the project to use JDK 24.

### Problem It Solves
The project previously used an older JDK version. Upgrading to JDK 24 enables compatibility with the latest Java features, performance improvements, and security updates.

### Key Changes Made
- Updated configuration and code to target JDK 24.
- Made 45 additions and 9 deletions across 2 files.
- Includes 5 commits for implementation and refinement.

### New Features / Functionality Introduced
- Enables the use of new language features and improvements available in JDK 24.

### Breaking Changes
- Projects or environments dependent on the previous JDK version may need to upgrade to JDK 24 to build and run the code.

### Testing Done
- No specific details about testing are included in the PR metadata. You may want to check the CI results or related test files for more information.

### Documentation Updates
- No documentation updates are noted in the PR summary. If documentation is affected, it should be updated to reflect the new JDK requirement.

