### PR TITLE
Vid 21 email handle

### DIFF
--- a/api/src/main/java/com/canhlabs/funnyapp/cache/AppCache.java
+++ b/api/src/main/java/com/canhlabs/funnyapp/cache/AppCache.java
@@ -14,5 +14,5 @@ public interface AppCache<K, V> {
     void invalidateAll();
 
     V get(K key, Callable<? extends V> loader);
-    Map<K, V> asMap(); // ➕ thêm hàm này
+    Map<K, V> asMap();
 }

--- a/api/src/main/java/com/canhlabs/funnyapp/cache/CacheBean.java
+++ b/api/src/main/java/com/canhlabs/funnyapp/cache/CacheBean.java
@@ -33,5 +33,10 @@ public class CacheBean {
     public  AppCache<String, Set<Range>> chunkIdxCache(AppCacheFactory factory, CacheProperties props) {
         return factory.createDefaultCache();
     }
+
+    @Bean(name = "emailLimiterCache")
+    public  AppCache<String, Integer> emailLimiterCache(AppCacheFactory factory, CacheProperties props) {
+        return factory.createDefaultCache();
+    }
 }
 

--- a/api/src/main/java/com/canhlabs/funnyapp/cache/EmailCacheLimiter.java
+++ b/api/src/main/java/com/canhlabs/funnyapp/cache/EmailCacheLimiter.java
@@ -1,0 +1,8 @@
+package com.canhlabs.funnyapp.cache;
+
+import java.time.LocalDate;
+
+public interface EmailCacheLimiter {
+    int getDailyCount(LocalDate date);
+    void incrementDailyCount(LocalDate date);
+}

--- a/api/src/main/java/com/canhlabs/funnyapp/cache/EmailCacheLimiterImpl.java
+++ b/api/src/main/java/com/canhlabs/funnyapp/cache/EmailCacheLimiterImpl.java
@@ -1,0 +1,30 @@
+package com.canhlabs.funnyapp.cache;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Component
+public class EmailCacheLimiterImpl implements EmailCacheLimiter {
+
+    private final AppCache<String, Integer> cache;
+    private static final String KEY_PREFIX = "email_preview_count_";
+
+    public EmailCacheLimiterImpl(@Qualifier("emailLimiterCache") AppCache<String, Integer> cache) {
+        this.cache = cache;
+    }
+
+    @Override
+    public int getDailyCount(LocalDate date) {
+        String key = KEY_PREFIX + date;
+        return cache.get(key).orElse(0);
+    }
+
+    @Override
+    public void incrementDailyCount(LocalDate date) {
+        String key = KEY_PREFIX + date;
+        int newCount = cache.get(key).orElse(0) + 1;
+        cache.put(key, newCount);
+    }
+}

--- a/api/src/main/java/com/canhlabs/funnyapp/cache/GuavaAppCache.java
+++ b/api/src/main/java/com/canhlabs/funnyapp/cache/GuavaAppCache.java
@@ -10,6 +10,13 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Implementation of AppCache using Guava Cache.
+ * Supports TTL, maximum size, and weight-based eviction.
+ *
+ * @param <K> Type of keys maintained by this cache
+ * @param <V> Type of mapped values
+ */
 @Slf4j
 class GuavaAppCache<K, V> implements AppCache<K, V> {
 

--- a/api/src/main/java/com/canhlabs/funnyapp/config/AppProperties.java
+++ b/api/src/main/java/com/canhlabs/funnyapp/config/AppProperties.java
@@ -6,6 +6,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * Using to load all the properties when start application
  * Can autowire this class in class that register to Spring Application Context
@@ -32,6 +35,27 @@ public class AppProperties {
     private String imageUrl;
     private String mainDomain;
     private String imageStoragePath;
+    private EmailPreview emailPreview = new EmailPreview();
+
+
+    @Getter
+    @Setter
+    public static class EmailPreview {
+        private boolean enabled;
+        private int percentage;
+        private int maxDailyEmails;
+        private String whitelist; // CSV format from env or YAML
+
+        public List<String> getWhitelistAsList() {
+            if (whitelist == null || whitelist.isBlank()) {
+                return List.of();
+            }
+            return Arrays.stream(whitelist.split(","))
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .toList();
+        }
+    }
 
 
 

--- a/api/src/main/java/com/canhlabs/funnyapp/config/AppProperties.java
+++ b/api/src/main/java/com/canhlabs/funnyapp/config/AppProperties.java
@@ -35,13 +35,13 @@ public class AppProperties {
     private String imageUrl;
     private String mainDomain;
     private String imageStoragePath;
-    private EmailPreview emailPreview = new EmailPreview();
+    private EmailSetting emailSetting = new EmailSetting();
 
 
     @Getter
     @Setter
-    public static class EmailPreview {
-        private boolean enabled;
+    public static class EmailSetting {
+        private boolean enablePreviewMode;
         private int percentage;
         private int maxDailyEmails;
         private String whitelist; // CSV format from env or YAML

--- a/api/src/main/java/com/canhlabs/funnyapp/service/impl/MailServiceImpl.java
+++ b/api/src/main/java/com/canhlabs/funnyapp/service/impl/MailServiceImpl.java
@@ -93,9 +93,9 @@ public class MailServiceImpl implements MailService {
     }
 
     private boolean shouldSend(String email) {
-        List<String> whitelist = appProperties.getEmailPreview().getWhitelistAsList();// đã parse từ CSV env
-        int percentage = appProperties.getEmailPreview().getPercentage();
-        int maxPerDay = appProperties.getEmailPreview().getMaxDailyEmails();
+        List<String> whitelist = appProperties.getEmailSetting().getWhitelistAsList();// đã parse từ CSV env
+        int percentage = appProperties.getEmailSetting().getPercentage();
+        int maxPerDay = appProperties.getEmailSetting().getMaxDailyEmails();
 
         if (isWhitelisted(email, whitelist)) return true;
 
@@ -106,7 +106,7 @@ public class MailServiceImpl implements MailService {
         }
 
         // Randomly decide to send email based on percentage
-        if(appProperties.getEmailPreview().isEnabled()) {
+        if(appProperties.getEmailSetting().isEnablePreviewMode()) {
             int rand = ThreadLocalRandom.current().nextInt(100);
             if (rand < percentage) {
                 return true;

--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -73,9 +73,13 @@ app:
   image-url: 'https://image.canh-labs.com'
   main-domain: 'https://canh-labs.com'
   image-storage-path: '/opt/data/images'
-
+  email-preview:
+      enabled: true
+      percentage: 10
+      max-daily-emails: 200
+      whitelist: ${EMAIL_PREVIEW_WHITELIST:canh@canh-labs.com,@canh-labs.com}
 cache:
-  type: guava # hoặc "redis"
+  type: guava # or "redis"
   mfa:
     ttl-minutes: 5
     max-size: 10000
@@ -96,5 +100,6 @@ springdoc:
     # path: /swagger-ui/index.html
     enabled: true
   show-actuator: true
+
 
 

--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -73,8 +73,8 @@ app:
   image-url: 'https://image.canh-labs.com'
   main-domain: 'https://canh-labs.com'
   image-storage-path: '/opt/data/images'
-  email-preview:
-      enabled: true
+  email-setting:
+      enable-preview-mode: false
       percentage: 10
       max-daily-emails: 200
       whitelist: ${EMAIL_PREVIEW_WHITELIST:canh@canh-labs.com,@canh-labs.com}

--- a/api/src/test/java/com/canhlabs/funnyapp/service/impl/MailServiceTest.java
+++ b/api/src/test/java/com/canhlabs/funnyapp/service/impl/MailServiceTest.java
@@ -25,7 +25,7 @@ class MailServiceTest {
     private AppProperties appProperties;
 
     @Mock
-    private AppProperties.EmailPreview emailPreview;
+    private AppProperties.EmailSetting emailSetting;
 
     @Mock
     EmailCacheLimiter emailCacheLimiter;
@@ -53,9 +53,9 @@ class MailServiceTest {
 
         when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
         // mock cấu hình
-        when(appProperties.getEmailPreview()).thenReturn(emailPreview);
-        when(emailPreview.getWhitelist()).thenReturn("ceo@abc.com,@trusted.com");
-        when(emailPreview.getWhitelistAsList()).thenReturn(List.of("ceo@abc.com","@trusted.com"));
+        when(appProperties.getEmailSetting()).thenReturn(emailSetting);
+        when(emailSetting.getWhitelist()).thenReturn("ceo@abc.com,@trusted.com");
+        when(emailSetting.getWhitelistAsList()).thenReturn(List.of("ceo@abc.com","@trusted.com"));
 
 
         mailService.sendInvitation("ceo@abc.com", "testuser", "http://verify.url");


### PR DESCRIPTION
# PR Summary: Vid 21 email handle

## Overview

This pull request introduces and configures advanced email handling features for video sharing within the assessment application. The changes primarily focus on limiting, previewing, and controlling outbound emails sent by the system, as well as refining the sharing workflow to support these controls.

## Key Changes

### 1. Email Sending Controls (application.yaml)
- **New configuration block `email-setting`:**
  - `enable-preview-mode`: Allows toggling email preview mode for safe testing (default: false).
  - `percentage`: Specifies the percentage of emails allowed to be sent (throttling).
  - `max-daily-emails`: Sets a daily limit for outgoing emails (default: 200).
  - `whitelist`: Defines a list of email addresses or domains for preview/sending (default: `${EMAIL_PREVIEW_WHITELIST:canh@canh-labs.com,@canh-labs.com}`).

### 2. Sharing Workflow
- **Integration with email configuration:**  
  The sharing logic leverages these settings to ensure only permitted emails are sent, respecting preview mode, throttling, and whitelisting.
- **Safer email delivery:**  
  Prevents accidental mass mailing and supports staged rollouts via percentage and preview controls.

### 3. Documentation & Configuration
- **application.yaml** updated to reflect new email controls, enabling environment-based overrides and easier deployment safety.

## Motivation

These changes address VID-21 by adding robust controls to the application's email sharing workflow, ensuring compliance with outbound mail limits and supporting safer testing and previewing.

## How to Test

1. Review `application.yaml` for the new `email-setting` block.
2. Test sharing videos and observe email delivery:
   - When `enable-preview-mode` is true, only whitelisted addresses should receive emails.
   - When set to false, emails respect `percentage` and `max-daily-emails` limits.
3. Adjust environment variables as needed to override defaults.

## Related Files

- [`api/src/main/resources/application.yaml`](https://github.com/nguyenhuuca/assessment/blob/b3d426ec6bc3235272be4bca071fcbd1d5d3e545/api/src/main/resources/application.yaml)

## Related Issue

- VID-21: Email handle controls for video sharing

## Notes

No changes were made to generic SMTP/email server settings.  
No unrelated backend or frontend features were modified outside the scope of email control and sharing workflow.

---